### PR TITLE
Small fixes

### DIFF
--- a/src/view-models/client-view-model.js
+++ b/src/view-models/client-view-model.js
@@ -229,7 +229,7 @@ export class ClientViewModel {
       const pattern = /#cmd\[(.*?)\]/g;
       const match = pattern.exec(event.target.hash);
       if (!match) { return true; }
-      const command = match[1];
+      const command = decodeURIComponent(match[1]); // URI-encoded on some browsers (e.g. Firefox)
       this.command(command);
       this.sendCommand();
       return false;

--- a/src/view-models/client-view-model.js
+++ b/src/view-models/client-view-model.js
@@ -18,7 +18,14 @@ export class ClientViewModel {
   constructor(parentViewModel) {
     // Elements
 
-    this.$body = document.querySelector('body');
+    // Scrolling element is body on Webkit-based browsers,
+    // html on Firefox and Internet Explorer. All recent
+    // browsers tend to support document.scrollingElement from
+    // CSSOM working draft.
+    this.$scrollingElement = document.scrollingElement;
+    if (typeof this.$scrollingElement === 'undefined') {
+      this.$scrollingElement = document.querySelector('html');
+    }
 
     // Properties
 
@@ -169,7 +176,7 @@ export class ClientViewModel {
   }
 
   scrollToBottom() {
-    this.$body.scrollTop = this.$body.scrollHeight - window.innerHeight;
+    this.$scrollingElement.scrollTop = this.$scrollingElement.scrollHeight - window.innerHeight;
   }
 
   truncateHistory() {

--- a/src/view-models/tabs-view-model.js
+++ b/src/view-models/tabs-view-model.js
@@ -95,12 +95,14 @@ export class TabsViewModel {
 
   newEditVerbTab(socket, data) {
     const newTab = new VerbEditorTabViewModel(this, socket, data);
+    this.closeSameTabs(newTab);
     this.tabs.push(newTab);
     newTab.select();
   }
 
   newEditFunctionTab(socket, data) {
     const newTab = new FunctionEditorTabViewModel(this, socket, data);
+    this.closeSameTabs(newTab);
     this.tabs.push(newTab);
     newTab.select();
   }
@@ -116,6 +118,15 @@ export class TabsViewModel {
     } else {
       this.activeTab(null);
     }
+  }
+
+  closeSameTabs(tab) {
+    // Close other tabs with same names, only if they are not edited
+    this.tabs().forEach(t => {
+      if (t.name() === tab.name() && !t.dirty()) {
+        this.closeTab(t);
+      }
+    });
   }
 
   onKeyDown(...args) {


### PR DESCRIPTION
Just a bunch of small fixes:
- Fix #6 (links with spaces) and #7 (page scrolling) for Firefox
- Implement #5 to avoid multiple tabs by same name, unless they are marked dirty.